### PR TITLE
Some fix-ups for macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ SRCS		 = jftp.c parserow.c spegla.c tgetopt.c container.c spf_util.c	\
 			   regcomp.c regerror.c regexec.c regfree.c
 .if !(defined(HAVE_STRLCPY) && ${HAVE_STRLCPY} == "yes")
 SRCS		+= strlcpy.c
-CPPFLAGS	+= -DNO_STRLCPY
+#CPPFLAGS	+= -DNO_STRLCPY
 .endif
 
 MAN			 = spegla.1

--- a/Makefile.macosx
+++ b/Makefile.macosx
@@ -1,0 +1,40 @@
+#  $Id: Makefile.linux,v 1.5 1999/12/17 00:44:27 jens Exp $
+OBJS = spegla.o jftp.o parserow.o e_err.o tgetopt.o container.o \
+		que_syms.o spf_util.o strlcpy.o
+
+CC ?= gcc
+DEFS ?=
+CFLAGS = -c -Wall -g
+
+spegla: ${OBJS}
+	$(CC) -o spegla ${OBJS} ${LDFLAGS}
+
+parserow.o: parserow.c
+	$(CC) ${CFLAGS} parserow.c ${DEFS}
+
+spf_util.o: spf_util.c
+	$(CC) ${CFLAGS} spf_util.c ${DEFS}
+
+tgetopt.o: tgetopt.c
+	$(CC) ${CFLAGS} tgetopt.c ${DEFS}
+
+e_err.o: e_err.c
+	$(CC) ${CFLAGS} e_err.c ${DEFS}
+
+container.o: container.c
+	$(CC) ${CFLAGS} container.c ${DEFS}
+
+que_syms.o: que_syms.c
+	$(CC) ${CFLAGS} que_syms.c ${DEFS}
+
+strlcpy.o: strlcpy.c
+	$(CC) ${CFLAGS} strlcpy.c ${DEFS}
+
+jftp.o: jftp.c
+	$(CC) ${CFLAGS} jftp.c ${DEFS}
+
+spegla.o: spegla.c
+	$(CC) ${CFLAGS} spegla.c ${DEFS}
+
+clean: 
+	/bin/rm -f *.o spegla

--- a/jftp.c
+++ b/jftp.c
@@ -52,7 +52,8 @@
 #include <fcntl.h>
 #include <stdlib.h>
 
-#ifdef NO_STRLCPY
+#if !(defined(__APPLE__) && defined(__clang__))
+/* On macOS with Clang a conflict with the OS headers arises */
 #include "strlcpy.h"
 #endif
 

--- a/parserow.c
+++ b/parserow.c
@@ -51,7 +51,10 @@
 #		define DAYSPERNYEAR 365
 #	endif
 #endif
+#if !(defined(__APPLE__) && defined(__clang__))
+/* On macOS with Clang a conflict with the OS headers arises */
 #include "strlcpy.h"
+#endif
 #include "parserow.h"
 #include "spegla.h"
 

--- a/spegla.c
+++ b/spegla.c
@@ -67,7 +67,10 @@
 #include <signal.h>
 #include <pwd.h>
 
+#if !(defined(__APPLE__) && defined(__clang__))
+/* On macOS with Clang a conflict with the OS headers arises */
 #include "strlcpy.h"
+#endif
 #include "spegla.h"
 #include "parserow.h"
 #include "jftp.h"

--- a/spf_util.c
+++ b/spf_util.c
@@ -45,7 +45,8 @@
 #include <limits.h>
 #include <unistd.h>
 
-#ifdef NO_STRLCPY
+#if !(defined(__APPLE__) && defined(__clang__))
+/* On macOS with Clang a conflict with the OS headers arises */
 #include "strlcpy.h"
 #endif
 

--- a/strlcat.c
+++ b/strlcat.c
@@ -31,6 +31,7 @@
 #include <sys/types.h>
 #include <string.h>
 
+#if !(defined(__APPLE__) && defined(__clang__))
 /*
  * Appends src to string dst of size siz (unlike strncat, siz is the
  * full size of dst, not space left).  At most siz-1 characters
@@ -66,3 +67,4 @@ size_t strlcat(dst, src, siz)
 
 	return(dlen + (s - src));	/* count does not include NUL */
 }
+#endif

--- a/strlcpy.c
+++ b/strlcpy.c
@@ -33,6 +33,7 @@
 
 #include "strlcpy.h"
 
+#if !(defined(__APPLE__) && defined(__clang__))
 /*
  * Copy src to string dst of size siz.  At most siz-1 characters
  * will be copied.  Always NUL terminates (unless siz == 0).
@@ -65,3 +66,4 @@ size_t strlcpy(dst, src, siz)
 
 	return(s - src - 1);	/* count does not include NUL */
 }
+#endif

--- a/strlcpy.h
+++ b/strlcpy.h
@@ -2,8 +2,10 @@
 #ifndef STRLCPY__H
 #define STRLCPY__H
 
+#if !(defined(__APPLE__) && defined(__clang__))
+/* On macOS with Clang a conflict with the OS headers arises */
 size_t strlcpy(char *dst, const char *src, size_t size);
 size_t strlcat(char *dst, const char *src, size_t size);
+#endif
 
 #endif /* STRLCPY__H */
-


### PR DESCRIPTION
P. S. I have dropped the define `NO_STRLCPY` since it becomes redundant in the sources. It also makes little sense to require a manual define for a common case. A special case is macOS with clang, where a conflict with system headers arises. Even on macOS itself with GCC the build is fine.